### PR TITLE
Release 1.2.0

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This guide adds package-specific rules to the host repository guide. Consumer us
 
 ## Runtime invariants
 
-- Native alerts accept one to three buttons with unique text and unique `AlertButtonStyle` values. A non-dismissible alert cannot be an action sheet because iOS retains outside-tap dismissal for that presentation style.
+- Native alerts accept one to three buttons with unique text and unique `AlertButtonStyle` values. A non-dismissible alert cannot be an action sheet because iOS retains outside-tap dismissal for that presentation style. Calls originate on Unity's main thread; every platform callback returns to the synchronization context captured when the alert was shown.
 - `RequestReview()` is fire-and-forget. The OS may suppress the prompt and provides no “shown” result; do not invent success callbacks or a store-URL fallback. Android Play review depends on the configured Play Core review artifact, which the native-build postprocessor injects unless explicitly disabled.
 - `MobileNotificationService` owns its `NotificationService` GameObject. Disposal is idempotent, releases only owned resources, and public operations depending on the host throw `ObjectDisposedException` afterward. Shared validation and lifecycle behavior stay outside platform conditionals.
 - Android notification scheduling requires a registered default channel. Queue modes hand pending work to the OS on background transitions.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -19,7 +19,7 @@ This guide adds package-specific rules to the host repository guide. Consumer us
 
 ## Runtime invariants
 
-- Native alerts accept one to three buttons with unique text and unique `AlertButtonStyle` values. A non-dismissible alert cannot be an action sheet because iOS retains outside-tap dismissal for that presentation style. Calls originate on Unity's main thread; every platform callback returns to the synchronization context captured when the alert was shown.
+- Native alerts accept one to three buttons with unique text and unique `AlertButtonStyle` values. A non-dismissible alert cannot be an action sheet because iOS retains outside-tap dismissal for that presentation style. `ShowAlertPopUpAsync` is the preferred API; it returns the selected index through one pooled `Awaitable`, while legacy callbacks switch through `Awaitable.MainThreadAsync`. Dismissing or replacing an async alert cancels its await.
 - `RequestReview()` is fire-and-forget. The OS may suppress the prompt and provides no “shown” result; do not invent success callbacks or a store-URL fallback. Android Play review depends on the configured Play Core review artifact, which the native-build postprocessor injects unless explicitly disabled.
 - `MobileNotificationService` owns its `NotificationService` GameObject. Disposal is idempotent, releases only owned resources, and public operations depending on the host throw `ObjectDisposedException` afterward. Shared validation and lifecycle behavior stay outside platform conditionals.
 - Android notification scheduling requires a registered default channel. Queue modes hand pending work to the OS on background transitions.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,8 +7,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+**New**:
+- Added `ShowAlertPopUpAsync`, which returns the selected button index through Unity's `Awaitable` API.
+
 **Fixed**:
-- Alert button callbacks now return to Unity's captured synchronization context before invoking consumer code.
+- Alert button callbacks now return through `Awaitable.MainThreadAsync` before invoking consumer code.
 
 ## [1.1.0] - 2026-08-13
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
-## [Unreleased]
+## [1.2.0] - 2026-08-14
 
 **New**:
 - Added `ShowAlertPopUpAsync`, which returns the selected button index through Unity's `Awaitable` API.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,11 @@ All notable changes to this package will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+**Fixed**:
+- Alert button callbacks now return to Unity's captured synchronization context before invoking consumer code.
+
 ## [1.1.0] - 2026-08-13
 
 **New**:

--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Use Mobile Services to isolate platform-specific behavior behind Unity-friendly 
 ```json
 {
   "dependencies": {
-    "com.gamelovers.mobileservices": "https://github.com/CoderGamester/Unity-MobileServices.git#1.0.1"
+    "com.gamelovers.mobileservices": "https://github.com/CoderGamester/Unity-MobileServices.git#1.2.0"
   }
 }
 ```
@@ -79,7 +79,7 @@ Use the specific subsystem namespaces—`Notifications`, `Haptics`, `NativeUi`, 
 | Gestures | Gesture controller for explicit gesture input ownership |
 | Editor tooling | Device Simulator integration and build helpers |
 
-Runtime alert calls render an interactive platform-shaped mock in the Game view even when the Device Simulator window is closed, and alert callbacks return to Unity's captured synchronization context on every platform. The editor simulator is for exercising application paths; it is not a substitute for device permission, notification-delivery, review, or native-build validation.
+Runtime alert calls render an interactive platform-shaped mock in the Game view even when the Device Simulator window is closed. Prefer `ShowAlertPopUpAsync` for a selected-index result on Unity's main thread; legacy callbacks also switch through Unity's `Awaitable` scheduler. The editor simulator is for exercising application paths; it is not a substitute for device permission, notification-delivery, review, or native-build validation.
 
 ## Sample and support
 

--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ Use the specific subsystem namespaces—`Notifications`, `Haptics`, `NativeUi`, 
 | Gestures | Gesture controller for explicit gesture input ownership |
 | Editor tooling | Device Simulator integration and build helpers |
 
-Runtime alert calls render an interactive platform-shaped mock in the Game view even when the Device Simulator window is closed. The editor simulator is for exercising application paths; it is not a substitute for device permission, notification-delivery, review, or native-build validation.
+Runtime alert calls render an interactive platform-shaped mock in the Game view even when the Device Simulator window is closed, and alert callbacks return to Unity's captured synchronization context on every platform. The editor simulator is for exercising application paths; it is not a substitute for device permission, notification-delivery, review, or native-build validation.
 
 ## Sample and support
 

--- a/Runtime/NativeUi/INativeUiService.cs
+++ b/Runtime/NativeUi/INativeUiService.cs
@@ -1,3 +1,5 @@
+using UnityEngine;
+
 // ReSharper disable once CheckNamespace
 namespace GameLovers.MobileServices.NativeUi
 {
@@ -14,6 +16,14 @@ namespace GameLovers.MobileServices.NativeUi
 
 		/// <inheritdoc cref="NativeUiService.ShowAlertPopUp(bool,bool,string,string,AlertButton[])"/>
 		void ShowAlertPopUp(
+			bool isAlertSheet,
+			bool isDismissible,
+			string title,
+			string message,
+			params AlertButton[] buttons);
+
+		/// <inheritdoc cref="NativeUiService.ShowAlertPopUpAsync(bool,bool,string,string,AlertButton[])"/>
+		Awaitable<int> ShowAlertPopUpAsync(
 			bool isAlertSheet,
 			bool isDismissible,
 			string title,
@@ -51,6 +61,15 @@ namespace GameLovers.MobileServices.NativeUi
 			string message,
 			params AlertButton[] buttons)
 			=> NativeUiService.ShowAlertPopUp(isAlertSheet, isDismissible, title, message, buttons);
+
+		/// <inheritdoc />
+		public Awaitable<int> ShowAlertPopUpAsync(
+			bool isAlertSheet,
+			bool isDismissible,
+			string title,
+			string message,
+			params AlertButton[] buttons)
+			=> NativeUiService.ShowAlertPopUpAsync(isAlertSheet, isDismissible, title, message, buttons);
 
 		/// <inheritdoc />
 		public void DismissAlertPopUp() => NativeUiService.DismissAlertPopUp();

--- a/Runtime/NativeUi/NativeUiService.cs
+++ b/Runtime/NativeUi/NativeUiService.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 #if UNITY_ANDROID
 using System.Collections.Generic;
 #endif
@@ -68,7 +69,8 @@ namespace GameLovers.MobileServices.NativeUi
 		/// <remarks>
 		/// A non-dismissible alert must use alert style, not action-sheet style. Alerts support one
 		/// to three buttons with unique labels and styles so the same descriptors map safely on iOS
-		/// and Android.
+		/// and Android. Call this API from Unity's main thread; button callbacks return to its captured
+		/// synchronization context before invocation.
 		/// </remarks>
 		public static void ShowAlertPopUp(
 			bool isAlertSheet,
@@ -78,6 +80,7 @@ namespace GameLovers.MobileServices.NativeUi
 			params AlertButton[] buttons)
 		{
 			ValidateAlert(isAlertSheet, isDismissible, buttons);
+			buttons = MarshalButtonCallbacks(buttons);
 
 #if UNITY_EDITOR
 			if (EditorShowAlertOverride != null)
@@ -214,6 +217,46 @@ namespace GameLovers.MobileServices.NativeUi
 #elif UNITY_ANDROID
 			ShareAndroid(text, url, imagePath, title);
 #endif
+		}
+
+		/// <summary>
+		/// Wraps a callback so a foreign platform thread posts it to the context captured by the caller.
+		/// </summary>
+		internal static Action MarshalCallbackToContext(
+			Action callback,
+			SynchronizationContext context,
+			int sourceThreadId)
+		{
+			if (callback == null)
+			{
+				return null;
+			}
+
+			return () =>
+			{
+				if (Thread.CurrentThread.ManagedThreadId == sourceThreadId || context == null)
+				{
+					callback();
+					return;
+				}
+
+				context.Post(_ => callback(), null);
+			};
+		}
+
+		private static AlertButton[] MarshalButtonCallbacks(AlertButton[] buttons)
+		{
+			var context = SynchronizationContext.Current;
+			int sourceThreadId = Thread.CurrentThread.ManagedThreadId;
+			var marshalledButtons = new AlertButton[buttons.Length];
+			for (var i = 0; i < buttons.Length; i++)
+			{
+				marshalledButtons[i] = buttons[i];
+				marshalledButtons[i].Callback =
+					MarshalCallbackToContext(buttons[i].Callback, context, sourceThreadId);
+			}
+
+			return marshalledButtons;
 		}
 
 		private static void ValidateAlert(bool isAlertSheet, bool isDismissible, AlertButton[] buttons)

--- a/Runtime/NativeUi/NativeUiService.cs
+++ b/Runtime/NativeUi/NativeUiService.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 #if UNITY_ANDROID
 using System.Collections.Generic;
 #endif
@@ -34,6 +33,9 @@ namespace GameLovers.MobileServices.NativeUi
 	/// </summary>
 	public static class NativeUiService
 	{
+		private static readonly object _alertCompletionLock = new object();
+		private static AwaitableCompletionSource<int> _currentAlertCompletion;
+
 #if UNITY_IOS
 		/// <summary>Native iOS callback signature; the button is identified by its text.</summary>
 		internal delegate void AlertButtonDelegate(string buttonText);
@@ -69,8 +71,8 @@ namespace GameLovers.MobileServices.NativeUi
 		/// <remarks>
 		/// A non-dismissible alert must use alert style, not action-sheet style. Alerts support one
 		/// to three buttons with unique labels and styles so the same descriptors map safely on iOS
-		/// and Android. Call this API from Unity's main thread; button callbacks return to its captured
-		/// synchronization context before invocation.
+		/// and Android. Call this API from Unity's main thread; button callbacks return there before
+		/// invocation.
 		/// </remarks>
 		public static void ShowAlertPopUp(
 			bool isAlertSheet,
@@ -80,42 +82,31 @@ namespace GameLovers.MobileServices.NativeUi
 			params AlertButton[] buttons)
 		{
 			ValidateAlert(isAlertSheet, isDismissible, buttons);
-			buttons = MarshalButtonCallbacks(buttons);
+			ObserveLegacyAlert(BeginAlert(isAlertSheet, isDismissible, title, message, buttons));
+		}
 
-#if UNITY_EDITOR
-			if (EditorShowAlertOverride != null)
-			{
-				EditorShowAlertOverride.Invoke(isAlertSheet, isDismissible, title, message, buttons);
-			}
-			else
-			{
-				Debug.Log($"Show Alert Pop Up is not available in the editor and was triggered with: {title} - {message}");
-			}
-#elif UNITY_IOS
-			_currentButtons = buttons;
-
-			var buttonsText = new string[buttons.Length];
-			var buttonsStyle = new int[buttons.Length];
-
-			for (var i = 0; i < buttons.Length; i++)
-			{
-				buttonsText[i] = buttons[i].Text;
-				buttonsStyle[i] = (int) buttons[i].Style;
-			}
-
-			AlertMessage(
-				isAlertSheet,
-				title,
-				message,
-				buttonsText,
-				buttonsStyle,
-				buttons.Length,
-				AlertButtonCallback);
-#elif UNITY_ANDROID
-			ShowAlertAndroid(isDismissible, title, message, buttons);
-#else
-			throw new SystemException("Show an alert Pop Up is only available for iOS and Android platforms");
-#endif
+		/// <summary>
+		/// Shows an alert and completes with the selected button index on Unity's main thread.
+		/// </summary>
+		/// <remarks>
+		/// Call from Unity's main thread and await the returned value once. Existing button callbacks
+		/// still run before the result is returned. Dismissing or replacing the alert cancels the await.
+		/// </remarks>
+		/// <param name="isAlertSheet">Whether iOS presents an action sheet instead of an alert.</param>
+		/// <param name="isDismissible">Whether the alert can close without selecting a button.</param>
+		/// <param name="title">Alert title.</param>
+		/// <param name="message">Alert message.</param>
+		/// <param name="buttons">Ordered alert actions.</param>
+		/// <returns>An awaitable containing the selected zero-based button index.</returns>
+		public static Awaitable<int> ShowAlertPopUpAsync(
+			bool isAlertSheet,
+			bool isDismissible,
+			string title,
+			string message,
+			params AlertButton[] buttons)
+		{
+			ValidateAlert(isAlertSheet, isDismissible, buttons);
+			return BeginAlert(isAlertSheet, isDismissible, title, message, buttons);
 		}
 
 		/// <summary>
@@ -154,6 +145,7 @@ namespace GameLovers.MobileServices.NativeUi
 		/// </summary>
 		public static void DismissAlertPopUp()
 		{
+			CancelCurrentAlert();
 #if UNITY_EDITOR
 			EditorDismissAlertOverride?.Invoke();
 #elif UNITY_IOS
@@ -219,44 +211,157 @@ namespace GameLovers.MobileServices.NativeUi
 #endif
 		}
 
-		/// <summary>
-		/// Wraps a callback so a foreign platform thread posts it to the context captured by the caller.
-		/// </summary>
-		internal static Action MarshalCallbackToContext(
-			Action callback,
-			SynchronizationContext context,
-			int sourceThreadId)
+		private static AlertButton[] BuildSelectionButtons(AlertButton[] buttons, Action<int> onSelected)
 		{
-			if (callback == null)
+			var selectionButtons = new AlertButton[buttons.Length];
+			for (var i = 0; i < buttons.Length; i++)
 			{
-				return null;
+				int buttonIndex = i;
+				selectionButtons[i] = buttons[i];
+				selectionButtons[i].Callback = () => onSelected(buttonIndex);
 			}
 
-			return () =>
+			return selectionButtons;
+		}
+
+		private static Awaitable<int> BeginAlert(
+			bool isAlertSheet,
+			bool isDismissible,
+			string title,
+			string message,
+			AlertButton[] buttons)
+		{
+			var completionSource = new AwaitableCompletionSource<int>();
+			ReplaceCurrentAlert(completionSource);
+			AlertButton[] selectionButtons = BuildSelectionButtons(
+				buttons,
+				index => CompleteAlert(completionSource, index));
+
+			try
 			{
-				if (Thread.CurrentThread.ManagedThreadId == sourceThreadId || context == null)
+				ShowAlertPopUpCore(isAlertSheet, isDismissible, title, message, selectionButtons);
+			}
+			catch
+			{
+				ClearCurrentAlert(completionSource);
+				throw;
+			}
+
+			return CompleteAlertAsync(completionSource, buttons);
+		}
+
+		private static async Awaitable<int> CompleteAlertAsync(
+			AwaitableCompletionSource<int> completionSource,
+			AlertButton[] buttons)
+		{
+			int selectedIndex = await completionSource.Awaitable;
+			await Awaitable.MainThreadAsync();
+			buttons[selectedIndex].Callback?.Invoke();
+			return selectedIndex;
+		}
+
+		private static void ShowAlertPopUpCore(
+			bool isAlertSheet,
+			bool isDismissible,
+			string title,
+			string message,
+			AlertButton[] buttons)
+		{
+#if UNITY_EDITOR
+			if (EditorShowAlertOverride != null)
+			{
+				EditorShowAlertOverride.Invoke(isAlertSheet, isDismissible, title, message, buttons);
+			}
+			else
+			{
+				Debug.Log($"Show Alert Pop Up is not available in the editor and was triggered with: {title} - {message}");
+			}
+#elif UNITY_IOS
+			_currentButtons = buttons;
+
+			var buttonsText = new string[buttons.Length];
+			var buttonsStyle = new int[buttons.Length];
+
+			for (var i = 0; i < buttons.Length; i++)
+			{
+				buttonsText[i] = buttons[i].Text;
+				buttonsStyle[i] = (int)buttons[i].Style;
+			}
+
+			AlertMessage(
+				isAlertSheet,
+				title,
+				message,
+				buttonsText,
+				buttonsStyle,
+				buttons.Length,
+				AlertButtonCallback);
+#elif UNITY_ANDROID
+			ShowAlertAndroid(isDismissible, title, message, buttons);
+#else
+			throw new SystemException("Show an alert Pop Up is only available for iOS and Android platforms");
+#endif
+		}
+
+		private static async void ObserveLegacyAlert(Awaitable<int> alert)
+		{
+			try
+			{
+				await alert;
+			}
+			catch (OperationCanceledException)
+			{
+			}
+		}
+
+		private static void ReplaceCurrentAlert(AwaitableCompletionSource<int> completionSource)
+		{
+			AwaitableCompletionSource<int> previous;
+			lock (_alertCompletionLock)
+			{
+				previous = _currentAlertCompletion;
+				_currentAlertCompletion = completionSource;
+			}
+
+			previous?.TrySetCanceled();
+		}
+
+		private static void CompleteAlert(AwaitableCompletionSource<int> completionSource, int selectedIndex)
+		{
+			lock (_alertCompletionLock)
+			{
+				if (_currentAlertCompletion != completionSource)
 				{
-					callback();
 					return;
 				}
 
-				context.Post(_ => callback(), null);
-			};
-		}
-
-		private static AlertButton[] MarshalButtonCallbacks(AlertButton[] buttons)
-		{
-			var context = SynchronizationContext.Current;
-			int sourceThreadId = Thread.CurrentThread.ManagedThreadId;
-			var marshalledButtons = new AlertButton[buttons.Length];
-			for (var i = 0; i < buttons.Length; i++)
-			{
-				marshalledButtons[i] = buttons[i];
-				marshalledButtons[i].Callback =
-					MarshalCallbackToContext(buttons[i].Callback, context, sourceThreadId);
+				_currentAlertCompletion = null;
 			}
 
-			return marshalledButtons;
+			completionSource.TrySetResult(selectedIndex);
+		}
+
+		private static void ClearCurrentAlert(AwaitableCompletionSource<int> completionSource)
+		{
+			lock (_alertCompletionLock)
+			{
+				if (_currentAlertCompletion == completionSource)
+				{
+					_currentAlertCompletion = null;
+				}
+			}
+		}
+
+		private static void CancelCurrentAlert()
+		{
+			AwaitableCompletionSource<int> completionSource;
+			lock (_alertCompletionLock)
+			{
+				completionSource = _currentAlertCompletion;
+				_currentAlertCompletion = null;
+			}
+
+			completionSource?.TrySetCanceled();
 		}
 
 		private static void ValidateAlert(bool isAlertSheet, bool isDismissible, AlertButton[] buttons)

--- a/Samples~/MobileServicesSamples/README.md
+++ b/Samples~/MobileServicesSamples/README.md
@@ -27,6 +27,8 @@ The Overview view covers package areas that are not duplicated by the focused vi
 
 The live device card reports battery, low-power, keep-awake, ATT, and safe-area state on separate lines. The Editor and Device Simulator use safe no-op or mock implementations where an operating-system feature is unavailable.
 
+The Overview alert controls keep the callback overload so their activity log can demonstrate legacy integration. For new consumer flows that need the selected zero-based button index, prefer `NativeUiService.ShowAlertPopUpAsync`; dismissal or replacement cancels its `Awaitable<int>`.
+
 ## Haptics
 
 The Haptics view exposes every preset—`Selection`, `Success`, `Warning`, `Error`, and the five impact presets—with three duration modes:

--- a/Tests/EditMode/Unit/NativeUiServiceInstanceTest.cs
+++ b/Tests/EditMode/Unit/NativeUiServiceInstanceTest.cs
@@ -29,6 +29,7 @@ namespace GameLoversEditor.MobileServices.Tests
 		[TearDown]
 		public void Cleanup()
 		{
+			NativeUiService.DismissAlertPopUp();
 			NativeUiService.EditorShowAlertOverride = _showAlertOverride;
 			NativeUiService.EditorDismissAlertOverride = _dismissAlertOverride;
 		}
@@ -45,6 +46,25 @@ namespace GameLoversEditor.MobileServices.Tests
 
 			_instance.ShowAlertPopUp(false, "T", "M",
 				new AlertButton { Text = "OK", Style = AlertButtonStyle.Default });
+		}
+
+		[Test]
+		// ADMIT: NativeUiServiceInstance.ShowAlertPopUpAsync could fail to forward the selected button result.
+		// RCR: INativeUiService.cs NativeUiServiceInstance.ShowAlertPopUpAsync — return a never-completed Awaitable → RED (awaiter incomplete). 2026-08-14
+		public void ShowAlertPopUpAsync_ForwardsSelectedIndex()
+		{
+			NativeUiService.EditorShowAlertOverride = (_, _, _, _, buttons) => buttons[0].Callback();
+
+			Awaitable<int> operation = _instance.ShowAlertPopUpAsync(
+				false,
+				true,
+				"T",
+				"M",
+				new AlertButton { Text = "OK", Style = AlertButtonStyle.Default });
+			var awaiter = operation.GetAwaiter();
+
+			Assert.IsTrue(awaiter.IsCompleted);
+			Assert.AreEqual(0, awaiter.GetResult());
 		}
 
 		[Test]

--- a/Tests/EditMode/Unit/NativeUiServiceTest.cs
+++ b/Tests/EditMode/Unit/NativeUiServiceTest.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Threading;
 using GameLovers.MobileServices.NativeUi;
 using NUnit.Framework;
 using UnityEngine.TestTools;
@@ -95,6 +96,28 @@ namespace GameLoversEditor.MobileServices.Tests
 		}
 
 		[Test]
+		// ADMIT: NativeUiService.MarshalCallbackToContext could invoke an Android UI-thread callback before returning to Unity's context.
+		// RCR: NativeUiService.cs MarshalCallbackToContext — replace `context.Post(...)` with `callback()` → RED (callback ran before context drain). 2026-08-13
+		public void MarshalCallbackToContext_ForeignThread_PostsBeforeInvoking()
+		{
+			var context = new RecordingSynchronizationContext();
+			int callbackCount = 0;
+			Action callback = NativeUiService.MarshalCallbackToContext(
+				() => callbackCount++,
+				context,
+				Thread.CurrentThread.ManagedThreadId);
+			var thread = new Thread(callback.Invoke);
+
+			thread.Start();
+			thread.Join();
+
+			Assert.AreEqual(0, callbackCount);
+			Assert.AreEqual(1, context.PostCount);
+			context.ExecutePostedCallback();
+			Assert.AreEqual(1, callbackCount);
+		}
+
+		[Test]
 		// ADMIT: NativeUiService.ShowToastMessage could change the Editor diagnostic that stands in for the native toast.
 		// RCR: NativeUiService.cs ShowToastMessage — editor log text `Show Toast message` → `Show Toast msg` → RED (LogAssert expected message not received).
 		public void ShowToastMessage_InEditor_LogsAndDoesNotThrow()
@@ -134,5 +157,24 @@ namespace GameLoversEditor.MobileServices.Tests
 			Assert.DoesNotThrow(() => NativeUiService.Share("hi"));
 		}
 
+		private sealed class RecordingSynchronizationContext : SynchronizationContext
+		{
+			private SendOrPostCallback _callback;
+			private object _state;
+
+			public int PostCount { get; private set; }
+
+			public override void Post(SendOrPostCallback callback, object state)
+			{
+				PostCount++;
+				_callback = callback;
+				_state = state;
+			}
+
+			public void ExecutePostedCallback()
+			{
+				_callback(_state);
+			}
+		}
 	}
 }

--- a/Tests/EditMode/Unit/NativeUiServiceTest.cs
+++ b/Tests/EditMode/Unit/NativeUiServiceTest.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Threading;
 using GameLovers.MobileServices.NativeUi;
 using NUnit.Framework;
 using UnityEngine.TestTools;
@@ -27,6 +26,7 @@ namespace GameLoversEditor.MobileServices.Tests
 		[TearDown]
 		public void Cleanup()
 		{
+			NativeUiService.DismissAlertPopUp();
 			NativeUiService.EditorShowAlertOverride = _showAlertOverride;
 			NativeUiService.EditorDismissAlertOverride = _dismissAlertOverride;
 		}
@@ -96,25 +96,23 @@ namespace GameLoversEditor.MobileServices.Tests
 		}
 
 		[Test]
-		// ADMIT: NativeUiService.MarshalCallbackToContext could invoke an Android UI-thread callback before returning to Unity's context.
-		// RCR: NativeUiService.cs MarshalCallbackToContext — replace `context.Post(...)` with `callback()` → RED (callback ran before context drain). 2026-08-13
-		public void MarshalCallbackToContext_ForeignThread_PostsBeforeInvoking()
+		// ADMIT: NativeUiService.DismissAlertPopUp could leave an async alert awaiting forever.
+		// RCR: NativeUiService.cs DismissAlertPopUp — remove `CancelCurrentAlert()` → RED (awaiter incomplete). 2026-08-14
+		public void DismissAlertPopUp_AsyncAlert_CancelsAwait()
 		{
-			var context = new RecordingSynchronizationContext();
-			int callbackCount = 0;
-			Action callback = NativeUiService.MarshalCallbackToContext(
-				() => callbackCount++,
-				context,
-				Thread.CurrentThread.ManagedThreadId);
-			var thread = new Thread(callback.Invoke);
+			NativeUiService.EditorShowAlertOverride = (_, _, _, _, _) => { };
+			Awaitable<int> operation = NativeUiService.ShowAlertPopUpAsync(
+				false,
+				true,
+				"T",
+				"M",
+				new AlertButton { Text = "OK", Style = AlertButtonStyle.Default });
+			var awaiter = operation.GetAwaiter();
 
-			thread.Start();
-			thread.Join();
+			NativeUiService.DismissAlertPopUp();
 
-			Assert.AreEqual(0, callbackCount);
-			Assert.AreEqual(1, context.PostCount);
-			context.ExecutePostedCallback();
-			Assert.AreEqual(1, callbackCount);
+			Assert.IsTrue(awaiter.IsCompleted);
+			Assert.Throws<OperationCanceledException>(() => awaiter.GetResult());
 		}
 
 		[Test]
@@ -157,24 +155,5 @@ namespace GameLoversEditor.MobileServices.Tests
 			Assert.DoesNotThrow(() => NativeUiService.Share("hi"));
 		}
 
-		private sealed class RecordingSynchronizationContext : SynchronizationContext
-		{
-			private SendOrPostCallback _callback;
-			private object _state;
-
-			public int PostCount { get; private set; }
-
-			public override void Post(SendOrPostCallback callback, object state)
-			{
-				PostCount++;
-				_callback = callback;
-				_state = state;
-			}
-
-			public void ExecutePostedCallback()
-			{
-				_callback(_state);
-			}
-		}
 	}
 }

--- a/Tests/PlayMode/Unit/NativeUiServicePlayModeTest.cs
+++ b/Tests/PlayMode/Unit/NativeUiServicePlayModeTest.cs
@@ -1,0 +1,94 @@
+using System;
+using System.Collections;
+using System.Threading;
+using GameLovers.MobileServices.NativeUi;
+using NUnit.Framework;
+using UnityEngine;
+using UnityEngine.TestTools;
+
+// ReSharper disable once CheckNamespace
+namespace GameLoversEditor.MobileServices.Tests
+{
+	public class NativeUiServicePlayModeTest
+	{
+		private Action<bool, bool, string, string, AlertButton[]> _showAlertOverride;
+
+		[SetUp]
+		public void Init()
+		{
+			_showAlertOverride = NativeUiService.EditorShowAlertOverride;
+		}
+
+		[TearDown]
+		public void Cleanup()
+		{
+			NativeUiService.DismissAlertPopUp();
+			NativeUiService.EditorShowAlertOverride = _showAlertOverride;
+		}
+
+		[UnityTest]
+		// ADMIT: NativeUiService.ShowAlertPopUp could stop observing the shared async alert path and lose legacy callbacks.
+		// RCR: NativeUiService.cs ShowAlertPopUp — replace the BeginAlert call with `CancelCurrentAlert()` → RED (native alert was not presented). 2026-08-14
+		public IEnumerator ShowAlertPopUp_ForeignSelection_InvokesCallbackOnUnityMainThread()
+		{
+			int mainThreadId = Thread.CurrentThread.ManagedThreadId;
+			int callbackThreadId = 0;
+			AlertButton[] renderedButtons = null;
+			NativeUiService.EditorShowAlertOverride = (_, _, _, _, buttons) => renderedButtons = buttons;
+
+			NativeUiService.ShowAlertPopUp(
+				false,
+				true,
+				"Title",
+				"Message",
+				new AlertButton
+				{
+					Text = "Continue",
+					Style = AlertButtonStyle.Default,
+					Callback = () => callbackThreadId = Thread.CurrentThread.ManagedThreadId,
+				});
+			Assert.IsNotNull(renderedButtons, "Native alert was not presented.");
+			var thread = new Thread(renderedButtons[0].Callback.Invoke);
+
+			thread.Start();
+			thread.Join();
+			yield return null;
+
+			Assert.AreEqual(mainThreadId, callbackThreadId);
+		}
+
+		[UnityTest]
+		// ADMIT: NativeUiService.ShowAlertPopUpAsync could resume consumer code on Android's OS UI thread.
+		// RCR: NativeUiService.cs CompleteAlertAsync — remove `await Awaitable.MainThreadAsync()` → RED (operation completed on worker thread). 2026-08-14
+		public IEnumerator ShowAlertPopUpAsync_ForeignSelection_CompletesOnUnityMainThread()
+		{
+			int mainThreadId = Thread.CurrentThread.ManagedThreadId;
+			int callbackThreadId = 0;
+			AlertButton[] renderedButtons = null;
+			NativeUiService.EditorShowAlertOverride = (_, _, _, _, buttons) => renderedButtons = buttons;
+			Awaitable<int> operation = NativeUiService.ShowAlertPopUpAsync(
+				false,
+				true,
+				"Title",
+				"Message",
+				new AlertButton
+				{
+					Text = "Continue",
+					Style = AlertButtonStyle.Default,
+					Callback = () => callbackThreadId = Thread.CurrentThread.ManagedThreadId,
+				});
+			var awaiter = operation.GetAwaiter();
+			var thread = new Thread(renderedButtons[0].Callback.Invoke);
+
+			thread.Start();
+			thread.Join();
+
+			Assert.IsFalse(awaiter.IsCompleted);
+			yield return null;
+
+			Assert.IsTrue(awaiter.IsCompleted);
+			Assert.AreEqual(0, awaiter.GetResult());
+			Assert.AreEqual(mainThreadId, callbackThreadId);
+		}
+	}
+}

--- a/Tests/PlayMode/Unit/NativeUiServicePlayModeTest.cs.meta
+++ b/Tests/PlayMode/Unit/NativeUiServicePlayModeTest.cs.meta
@@ -1,0 +1,2 @@
+fileFormatVersion: 2
+guid: 3d1a86774f4ab4a42aa9378e400c4522

--- a/docs/native-ui.md
+++ b/docs/native-ui.md
@@ -46,6 +46,8 @@ public enum AlertButtonStyle
 
 Alerts accept one to three buttons. Labels and styles must each be unique within an alert: iOS matches callbacks by button text, while Android maps the three styles onto its three native button slots.
 
+Call `ShowAlertPopUp` from Unity's main thread. Every `AlertButton.Callback` returns to the synchronization context captured by that call before it invokes consumer code, including Android callbacks originating on the OS UI thread.
+
 The overload without `isDismissible` preserves the original dismissible behavior. Set `isDismissible: false` for blocking alerts that must remain until the user selects a button; non-dismissible action sheets are rejected because iOS action sheets can be dismissed outside the sheet.
 
 `DismissAlertPopUp()` closes the active alert without invoking an action. Showing a new alert replaces the current one.

--- a/docs/native-ui.md
+++ b/docs/native-ui.md
@@ -22,6 +22,19 @@ NativeUiService.RequestReview();
 NativeUiService.Share(text: "Check out my high score!", url: "https://example.com/game");
 ```
 
+## Async alerts (preferred)
+
+```csharp
+int selectedButton = await NativeUiService.ShowAlertPopUpAsync(
+    isAlertSheet: false,
+    isDismissible: false,
+    title: "Connection Lost",
+    message: "Please check your connection and try again.",
+    new AlertButton { Text = "Reconnect", Style = AlertButtonStyle.Default });
+```
+
+The returned `Awaitable<int>` completes on Unity's main thread with the selected zero-based button index. Await it exactly once because Unity pools `Awaitable` instances. Existing `AlertButton.Callback` actions still run before completion; omit them when the caller handles the returned index. Programmatic dismissal or replacement cancels the pending await.
+
 ## Instance API
 
 For mock-friendly consumer code:
@@ -46,7 +59,7 @@ public enum AlertButtonStyle
 
 Alerts accept one to three buttons. Labels and styles must each be unique within an alert: iOS matches callbacks by button text, while Android maps the three styles onto its three native button slots.
 
-Call `ShowAlertPopUp` from Unity's main thread. Every `AlertButton.Callback` returns to the synchronization context captured by that call before it invokes consumer code, including Android callbacks originating on the OS UI thread.
+Call alert APIs from Unity's main thread. Legacy `AlertButton.Callback` actions switch through `Awaitable.MainThreadAsync` before invoking consumer code, including Android callbacks originating on the OS UI thread.
 
 The overload without `isDismissible` preserves the original dismissible behavior. Set `isDismissible: false` for blocking alerts that must remain until the user selects a button; non-dismissible action sheets are rejected because iOS action sheets can be dismissed outside the sheet.
 

--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "com.gamelovers.mobileservices",
   "displayName": "Mobile Services",
   "author": "Miguel Tomas",
-  "version": "1.1.0",
+  "version": "1.2.0",
   "unity": "6000.0",
   "license": "MIT",
   "description": "Mobile platform services: local notifications, native UI, haptics, permissions, ATT, deep links, gestures, device helpers, and build/simulator tooling.",


### PR DESCRIPTION
**New**:
- Added `ShowAlertPopUpAsync`, which returns the selected button index through Unity's `Awaitable` API.

**Fixed**:
- Alert button callbacks now return through `Awaitable.MainThreadAsync` before invoking consumer code.
